### PR TITLE
Normalize Point angle to [0, 2π)

### DIFF
--- a/Geometry/Circle.cpp
+++ b/Geometry/Circle.cpp
@@ -4,7 +4,7 @@
 // y cualquier punto A,B,C
 Point circumCenter(const Point& A, const Point& B, const Point& C) {
   Point b = C - A, c = B - A;
-  assert(b.cross(c) != 0);
+  assert(!equal(b.cross(c), 0));
   return A + (b * c.sq() - c * b.sq()).perp() / b.cross(c) / 2;
 }
 
@@ -17,7 +17,7 @@ Point circlePoint(Point c, double r, double ang) {
 // y los pone en out. Si solo hay una interseccion el par de out es igual
 int circleLine(Point o, double r, Line l, pair<Point, Point>& out) {
   double h2 = r * r - l.sqDist(o);
-  if (h2 >= 0) {
+  if (greaterEqual(h2, 0)) {
     Point p = l.proj(o);
     Point h = l.v * sqrt(h2) / l.v.norm();
     out = {p - h, p + h};
@@ -31,13 +31,13 @@ int circleCircle(Point o1, double r1, Point o2, double r2,
                  pair<Point, Point>& out) {
   Point d = o2 - o1;
   double d2 = d.sq();
-  if (d2 == 0) {
-    assert(r1 != r2);  // los circulos son iguales
+  if (equal(d2, 0)) {
+    assert(!equal(r1, r2));  // los circulos son iguales
     return 0;
   }
   double pd = (d2 + r1 * r1 - r2 * r2) / 2;
   double h2 = r1 * r1 - pd * pd / d2;
-  if (h2 >= 0) {
+  if (greaterEqual(h2, 0)) {
     Point p = o1 + d * pd / d2, h = d.perp() * sqrt(h2 / d2);
     out = {p - h, p + h};
   }
@@ -60,15 +60,15 @@ double circlePoly(Point c, double r, vector<Point> ps) {
     Point d = q - p;
     auto a = d.dot(p) / d.sq(), b = (p.sq() - r * r) / d.sq();
     auto det = a * a - b;
-    if (det <= 0) return arg(p, q) * r2;
+    if (lessEqual(det, 0)) return arg(p, q) * r2;
     auto s = max(0., -a - sqrt(det)), t = min(1., -a + sqrt(det));
-    if (t < 0 || 1 <= s) return arg(p, q) * r2;
+    if (less(t, 0) || greaterEqual(s, 1)) return arg(p, q) * r2;
     Point u = p + d * s, v = p + d * t;
     return arg(p, u) * r2 + u.cross(v) / 2 + arg(v, q) * r2;
   };
   auto sum = 0.0;
   FOR(i, 0, SZ(ps))
-  sum += tri(ps[i] - c, ps[(i + 1) % SZ(ps)] - c);
+    sum += tri(ps[i] - c, ps[(i + 1) % SZ(ps)] - c);
   return sum;
 }
 
@@ -85,13 +85,13 @@ int tangents(Point o1, double r1, Point o2, double r2, bool inner,
   if (inner) r2 = -r2;
   Point d = o2 - o1;
   double dr = r1 - r2, d2 = d.sq(), h2 = d2 - dr * dr;
-  if (d2 == 0 || h2 < 0) {
-    assert(h2 != 0);
+  if (equal(d2, 0) || less(h2, 0)) {
+    assert(!equal(d2, 0));
     return 0;
   }
-  for (double sign : {-1, 1}) {
+  for (int sign : {-1, 1}) {
     Point v = (d * dr + d.perp() * sqrt(h2) * sign) / d2;
     out.push_back({o1 + v * r1, o2 + v * r2});
   }
-  return 1 + (h2 > 0);
+  return 1 + sgn(h2);
 }

--- a/Geometry/HalfPlane.cpp
+++ b/Geometry/HalfPlane.cpp
@@ -8,7 +8,6 @@
  */
 
 typedef double T;
-const double EPS = 1e-9;
 const double INF = 1e9;
 
 struct HalfPlane {
@@ -17,10 +16,10 @@ struct HalfPlane {
   HalfPlane() {}
   HalfPlane(Point _p, Point _q)
       : p(_p), pq(_q - _p), angle(atan2(pq.y, pq.x)) {}
-  bool operator<(HalfPlane b) const { return angle < b.angle; }
-  bool out(Point q) { return pq.cross(q - p) < EPS; }
+  bool operator<(HalfPlane b) const { return less(angle, b.angle); }
+  bool out(Point q) { return lessEqual(pq.cross(q - p), 0); }
   Point intersect(HalfPlane l) {
-    if (abs(pq.cross(l.pq)) < EPS) return Point{INF, INF};
+    if (equal(pq.cross(l.pq), 0)) return Point{INF, INF};
     return l.p + l.pq * ((p - l.p).cross(pq) / l.pq.cross(pq));
   }
 };
@@ -36,8 +35,8 @@ vector<Point> intersect(vector<HalfPlane> b) {
     while (q < h && b[i].out(c[h].intersect(c[h - 1]))) h--;
     while (q < h && b[i].out(c[q].intersect(c[q + 1]))) q++;
     c[++h] = b[i];
-    if (q < h && abs(c[h].pq.cross(c[h - 1].pq)) < EPS) {
-      if (c[h].pq.dot(c[h - 1].pq) <= 0) return {};
+    if (q < h && equal(c[h].pq.cross(c[h - 1].pq), 0)) {
+      if (lessEqual(c[h].pq.dot(c[h - 1].pq), 0)) return {};
       h--;
       if (b[i].out(c[h].p)) c[h] = b[i];
     }

--- a/Geometry/MinkowskiSum.cpp
+++ b/Geometry/MinkowskiSum.cpp
@@ -6,7 +6,7 @@
  */
 
 void reorder(vector<Point>& p) {
-  if (orient(p[0], p[1], p[2]) < -EPS) reverse(ALL(p));
+  if (less(orient(p[0], p[1], p[2]), 0)) reverse(ALL(p));
   int pos = 0;
   FOR(i, 1, SZ(p))
   if (Point{p[i].y, p[i].x} < Point{p[pos].y, p[pos].x}) pos = i;
@@ -27,8 +27,8 @@ vector<Point> minkowski_sum(vector<Point> p, vector<Point> q) {
   while (i + 2 < SZ(p) || j + 2 < SZ(q)) {
     r.pb(p[i] + q[j]);
     auto cross = (p[i + 1] - p[i]).cross(q[j + 1] - q[j]);
-    i += cross >= -EPS;
-    j += cross <= EPS;
+    i += greaterEqual(cross, 0);
+    j += lessEqual(cross, 0);
   }
   return r;
 }

--- a/Geometry/Point.cpp
+++ b/Geometry/Point.cpp
@@ -57,7 +57,10 @@ struct Point {
   T dot(Point p) { return x * p.x + y * p.y; }
   T cross(Point p) const { return x * p.y - y * p.x; }
   T cross(Point a, Point b) const { return (a - *this).cross(b - *this); }
-  double angle() const { return atan2(y, x); }
+  T angle() const {
+    T ang = atan2(y, x);
+    return ang < 0 ? ang + 2 * PI : ang;
+  }
 
   friend ostream& operator<<(ostream& os, Point p) {
     return os << "(" << p.x << "," << p.y << ")";

--- a/Geometry/Point.cpp
+++ b/Geometry/Point.cpp
@@ -4,9 +4,23 @@ constexpr double PI = acos(-1.0);
 inline double DEG_to_RAD(double d) { return (d * PI / 180.0); }
 inline double RAD_to_DEG(double r) { return (r * 180.0 / PI); }
 
-typedef double T;
+using T = double;
 
-int sgn(T x) { return (T(0) < x) - (x < T(0)); }
+int sgn(T x) {
+  if (x < -EPS) return -1;
+  if (x > EPS) return 1;
+  return 0;
+}
+// Operaciones de comparacion para punto flotante
+// Usar estas funciones en lugar de <, <=, >, >=, ==
+// cuando trabajes con doubles y tal operacion te afecta
+// el flujo del programa.
+// Para respuestas max, min son suficientes
+bool less(T a, T b) { return sgn(a - b) < 0; }
+bool lessEqual(T a, T b) { return sgn(a - b) <= 0; }
+bool greater(T a, T b) { return sgn(a - b) > 0; }
+bool greaterEqual(T a, T b) { return sgn(a - b) >= 0; }
+bool equal(T a, T b) { return sgn(a - b) == 0; }
 
 struct Point {
   T x, y;
@@ -21,8 +35,8 @@ struct Point {
   Point operator/(T d) const { return {x / d, y / d}; }  // Solo para punto flotante
 
   // Operaciones de comparacion para punto flotante
-  bool operator<(Point p) const { return x < p.x - EPS || (abs(x - p.x) <= EPS && y < p.y - EPS); }
-  bool operator==(Point p) const { return abs(x - p.x) <= EPS && abs(y - p.y) <= EPS; }
+  bool operator<(Point p) const { return less(x, p.x) || (equal(x, p.x) && less(y, p.y)); }
+  bool operator==(Point p) const { return equal(x, p.x) && equal(y, p.y); }
   bool operator!=(Point p) const { return !(*this == p); }
 
   // Operaciones de comparacion para enteros
@@ -52,11 +66,11 @@ struct Point {
 
 // Vector: p2-p1
 double dist(Point p1, Point p2) { return hypot(p1.x - p2.x, p1.y - p2.y); }
-bool isPerp(Point v, Point w) { return v.dot(w) == 0; }
+bool isPerp(Point v, Point w) { return equal(v.dot(w), 0); }
 //-1 -> left / 0 -> collinear / +1 -> right
 T orient(Point a, Point b, Point c) { return a.cross(b, c); }
-bool cw(Point a, Point b, Point c) { return orient(a, b, c) < EPS; }
-bool ccw(Point a, Point b, Point c) { return orient(a, b, c) > -EPS; }
+bool cw(Point a, Point b, Point c) { return less(orient(a, b, c), 0); }
+bool ccw(Point a, Point b, Point c) { return greater(orient(a, b, c), 0); }
 
 // ANGULOS
 // Para c++17


### PR DESCRIPTION
- Shift Point::angle() return range from [-π, π) to [0, 2π)
- Align angular interval logic with standard counter-clockwise sweeps starting at the positive X-axis
- Eliminate L > R wrapping edge cases caused by crossing the negative X-axis seam
